### PR TITLE
Add MediaArea Code Of Conduct

### DIFF
--- a/app/Resources/translations/messages.en.xlf
+++ b/app/Resources/translations/messages.en.xlf
@@ -42,6 +42,10 @@
         <source><![CDATA[menu.mediaarea.events]]></source>
         <target><![CDATA[Events]]></target>
       </trans-unit>
+      <trans-unit id="menu.mediaarea.conduct" approved="yes">
+        <source><![CDATA[menu.mediaarea.conduct]]></source>
+        <target><![CDATA[Code of conduct]]></target>
+      </trans-unit>
       <trans-unit id="218" approved="yes">
         <source><![CDATA[menu.mediaarea.legal]]></source>
         <target><![CDATA[Legal]]></target>

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -37,6 +37,15 @@ class DefaultController extends Controller
     }
 
     /**
+     * @Route("/Conduct", name="ma_conduct")
+     * @Template()
+     */
+    public function conductAction()
+    {
+        return array();
+    }
+
+    /**
      * @Route("/Legal", name="ma_legal")
      * @Template()
      */

--- a/src/AppBundle/Menu/MenuBuilder.php
+++ b/src/AppBundle/Menu/MenuBuilder.php
@@ -217,6 +217,7 @@ class MenuBuilder
         $menu['menu.mediaarea']->addChild('menu.mediaarea.about', array('route' => 'homepage'));
         $menu['menu.mediaarea']->addChild('menu.mediaarea.pro', array('route' => 'mi_support'))->setCurrent(false);
         $menu['menu.mediaarea']->addChild('menu.mediaarea.events', array('route' => 'ma_events'));
+        $menu['menu.mediaarea']->addChild('menu.mediaarea.conduct', array('route' => 'ma_conduct'));
         $menu['menu.mediaarea']->addChild('menu.mediaarea.legal', array('route' => 'ma_legal'));
 
         return $menu;

--- a/src/AppBundle/Resources/views/Default/conduct.html.twig
+++ b/src/AppBundle/Resources/views/Default/conduct.html.twig
@@ -1,0 +1,84 @@
+{% extends 'AppBundle::base.html.twig' %}
+
+{% block title %}Code Of Conduct{% endblock %}
+
+{% block body %}
+<h1 id="mediaarea-code-of-conduct">MediaArea Code of Conduct</h1>
+
+<h2 id="our-pledge">Our Pledge</h2>
+
+<p>In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.</p>
+
+<h2 id="our-standards">Our Standards</h2>
+
+<p>Examples of behavior that contributes to creating a positive environment
+include:</p>
+
+<ul>
+<li>Using welcoming and inclusive language</li>
+<li>Being respectful of differing viewpoints and experiences</li>
+<li>Gracefully accepting constructive criticism</li>
+<li>Focusing on what is best for the community</li>
+<li>Showing empathy towards other community members</li>
+</ul>
+
+<p>Examples of unacceptable behavior by participants include:</p>
+
+<ul>
+<li>The use of sexualized language or imagery and unwelcome sexual attention or
+advances</li>
+<li>Trolling, insulting/derogatory comments, and personal or political attacks</li>
+<li>Public or private harassment</li>
+<li>Publishing others&rsquo; private information, such as a physical or electronic
+address, without explicit permission</li>
+<li>Other conduct which could reasonably be considered inappropriate in a
+professional setting</li>
+</ul>
+
+<h2 id="our-responsibilities">Our Responsibilities</h2>
+
+<p>Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.</p>
+
+<p>Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.</p>
+
+<h2 id="scope">Scope</h2>
+
+<p>This code of conduct applies to all spaces managed by MediaArea, as well as
+public spaces when an individual is representing the project or its community.
+This includes IRC, the mailing lists, the issue tracker, physical events, and
+any other form of discussion space managed by MediaArea.</p>
+
+<p>In addition, violations of this code outside these spaces may affect a
+person's ability to participate within them.</p>
+
+<h2 id="enforcement">Enforcement</h2>
+
+<p>Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <a href="mailto:conduct@mediaarea.net">conduct@mediaarea.net</a>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.</p>
+
+<p>Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project&rsquo;s leadership.</p>
+
+<h2 id="attribution">Attribution</h2>
+
+<p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org">Contributor Covenant</a>, version 1.4.<br/>
+No change except the Scope paragraph which is adapted from the <a href="https://www.djangoproject.com/conduct/">Django Code Of Conduct</a>.<br/>
+<a href="https://creativecommons.org/licenses/by/4.0/>Creative Commons Attribution</a> license.</p>
+
+{% endblock %}

--- a/src/AppBundle/Resources/views/footer.html.twig
+++ b/src/AppBundle/Resources/views/footer.html.twig
@@ -11,6 +11,7 @@
                 <li><a href="{{ path('homepage') }}">{% trans %}menu.mediaarea.about{% endtrans %}</a></li>
                 <li><a href="{{ path('mi_support', {'_fragment': 'pro'}) }}">{% trans %}menu.mediaarea.pro{% endtrans %}</a></li>
                 <li><a href="{{ path('ma_events') }}">{% trans %}menu.mediaarea.events{% endtrans %}</a></li>
+                <li><a href="{{ path('ma_conduct') }}">{% trans %}menu.mediaarea.conduct{% endtrans %}</a></li>
                 <li><a href="{{ path('ma_legal') }}">{% trans %}menu.mediaarea.legal{% endtrans %}</a></li>
             </ul>
         </div>


### PR DESCRIPTION
I prefer to change the `Contributor Covenant` as little as possible, so I modified only the `Scope` part in order to have Code Of Conduct applicable everywhere we are instead of only on the Internet.
I think that the [Django Code Of Conduct](https://www.djangoproject.com/conduct/) is good for that, so I used it (with little adaptation) for the `Scope` part.