### PR TITLE
small typos fix

### DIFF
--- a/src/MediaInfoBundle/Resources/translations/messages.en.xlf
+++ b/src/MediaInfoBundle/Resources/translations/messages.en.xlf
@@ -392,7 +392,7 @@ If you want to use other compilers or options, you must <a href="%buildFromSourc
         <source><![CDATA[support.faq.dll.AccessIsDenied.content]]></source>
         <target><![CDATA[On some production servers, users have this message:
 <pre>Unable to load DLL 'MediaInfo.dll': Access is denied. (Exception from HRESULT: 0x80070005 (E_ACCESSDENIED))</pre>
-For certain strict server setups, the Local Service account that is executing the DLL is only allowed read permission. However, for personal development machine, it is sometimes less strict and given full access and works fine for the developer.<br/>
+For certain strict server setups, the Local Service account that is executing the DLL is only allowed read permission. However, for a personal development machine, it is sometimes less strict and given full access and works fine for the developer.<br/>
 You need to set "Read &amp; execute" rights for MediaInfo.dll when deploying.<br/>
 If you want to access HTTP(S)/FTP(S) files, you also need to set the same rights for the sidecar libcurl.dll file.<br/>
 If you use IIS, <code>IIS_IUSRS</code> user must have the "Read &amp; execute" rights on these files.]]></target>
@@ -823,9 +823,9 @@ Please choose your preferred method below.]]></target>
         <source><![CDATA[donate.location_currency]]></source>
         <target><![CDATA[We have located you in "%country%" your payment will be made in "%currency%". <a href="%contact%">Contact us</a> if we have not located you correctly.]]></target>
       </trans-unit>
-      <trans-unit id="donate.not_loggued_in" approved="yes">
-        <source><![CDATA[donate.not_loggued_in]]></source>
-        <target><![CDATA[You are not loggued you will not have the features reserved to our donators (like no ads) and the new features, please <a href="%login%">login</a> or <a href="%register%">register</a>.]]></target>
+      <trans-unit id="donate.not_logged_in" approved="yes">
+        <source><![CDATA[donate.not_logged_in]]></source>
+        <target><![CDATA[You are not logged in, you will not have access to the features reserved to our donors (like no ads) and new features, please <a href="%login%">login</a> or <a href="%register%">register</a>.]]></target>
       </trans-unit>
       <trans-unit id="177" approved="yes">
         <source><![CDATA[donate.flattr.title]]></source>

--- a/src/MediaInfoBundle/Resources/views/Default/donate.html.twig
+++ b/src/MediaInfoBundle/Resources/views/Default/donate.html.twig
@@ -11,7 +11,7 @@
 
 <h2>{% trans %}donate.paypal.title{% endtrans %}</h2>
 {% if country %}{% trans with { '%country%': country, '%currency%': currency, '%contact%': path('ma_contact') } %}donate.location_currency{% endtrans %}<br>{% endif %}
-{% if not app.user %}{% trans with { '%login%': path('fos_user_security_login'), '%register%': path('fos_user_registration_register') } %}donate.not_loggued_in{% endtrans %}<br>{% endif %}
+{% if not app.user %}{% trans with { '%login%': path('fos_user_security_login'), '%register%': path('fos_user_registration_register') } %}donate.not_logged_in{% endtrans %}<br>{% endif %}
 {{ include('@Payment/form.html.twig') }}
 
 <h2>{% trans %}donate.flattr.title{% endtrans %}</h2>

--- a/src/SupportUsBundle/Resources/views/Default/individual.html.twig
+++ b/src/SupportUsBundle/Resources/views/Default/individual.html.twig
@@ -52,7 +52,7 @@
 
 <div class="form-group pay">
     <div>
-        {% if not app.user %}{% trans with { '%login%': path('fos_user_security_login'), '%register%': path('fos_user_registration_register') } %}donate.not_loggued_in{% endtrans %}{% endif %}
+        {% if not app.user %}{% trans with { '%login%': path('fos_user_security_login'), '%register%': path('fos_user_registration_register') } %}donate.not_logged_in{% endtrans %}{% endif %}
         <p>Pay with:</p>
     </div>
     <div class="row">


### PR DESCRIPTION
fix typo mentioned at https://github.com/MediaArea/MediaInfo/pull/218#issuecomment-374904591 + small fix

let me know if you need https://github.com/MediaArea/MediaArea-Website/blob/e810865bd4d107f6d606ff47194cc5f04a1c7c2a/src/SupportUsBundle/Resources/views/Default/individual.html.twig#L55

and 

https://github.com/MediaArea/MediaArea-Website/blob/e810865bd4d107f6d606ff47194cc5f04a1c7c2a/src/MediaInfoBundle/Resources/views/Default/donate.html.twig#L14

corrected and others that may appear and be required due to `<trans-unit id` correction or if I should only correct the actual translation text.