### PR TITLE
Fix typo in BWFMetaEdit documentation

### DIFF
--- a/src/AVIMetaEditBundle/Resources/views/Usage/validationsRules.html.twig
+++ b/src/AVIMetaEditBundle/Resources/views/Usage/validationsRules.html.twig
@@ -13,7 +13,7 @@ AVI MetaEdit responds to rules and recommendations outlined by EBU, Microsoft, a
 
 <h4>Requirements</h4>
 
-ICMD: The ICMD field must not contain line breaks.
+ICMT: The ICMT field must not contain line breaks.
 
 <h4>Recommendations</h4>
 


### PR DESCRIPTION
Fixes MediaArea/BWFMetaEdit#198

Signed-off-by: Maxime Gervais <gervais.maxime@gmail.com>