### PR TITLE
Blog post: Log4j is not used in our products

### DIFF
--- a/src/BlogBundle/Posts/2021-12-15-log4j.md
+++ b/src/BlogBundle/Posts/2021-12-15-log4j.md
@@ -1,0 +1,20 @@
+---
+title:  "No Log4j in MediaArea products"
+date:   2021-12-15 08:00:00 CET
+excerpt: "Software developed by MediaArea doesn't contain Log4j so no Log4Shell vulnerability with them."
+tags: Security
+---
+
+TL;DR: software developed by MediaArea doesn't contain Log4j so no [Log4Shell](https://en.wikipedia.org/wiki/Log4Shell) vulnerability with them.
+
+As we receive several emails about the potential presence of Log4j in MediaArea products due to Log4Shell vulnerability, here is the public communication about it: we don't use Log4j in the products we develop.
+
+Log4j is not used in MediaInfo.  
+Log4j is not used in MediaConch (note: MediaConch can connect to other software, e.g. VeraPDF for PDF validation and DPF Manager for TIFF validation, which are in Java, if you use them you need to contact their maintainer as we don't maintain or provide them, we just permit their usage via a plugin interface).  
+Log4j is not used in RAWCooked.  
+Log4j is not used in QCTools.  
+Log4j is not used in DVRescue.  
+Log4j is not used in BWF MetaEdit.  
+Log4j is not used in AVI MetaEdit.  
+Log4j is not used in MOV MetaEdit.  
+Log4j is not used in DV Analyzer.  


### PR DESCRIPTION
It seems that we need to communicate about [Log4Shell](https://en.wikipedia.org/wiki/Log4Shell).