### PR TITLE
MediaInfo v24.01.1 (Mac binaries)

### DIFF
--- a/src/MediaInfoBundle/Resources/views/Download/macTable.html.twig
+++ b/src/MediaInfoBundle/Resources/views/Download/macTable.html.twig
@@ -1,6 +1,6 @@
 <tr>
     <th rowspan="2" colspan="2"><a href="https://geo.itunes.apple.com/app/mediainfo/id510620098">Mac App Store</a></th>
-    <td class="table-OS" colspan="3">macOS 10.10 to 13, x86_64 and arm64</td>
+    <td class="table-OS" colspan="3">macOS 10.10 to 14, x86_64 and arm64</td>
 </tr>
 <tr>
     <th><abbr title="Graphical User Interface">GUI</abbr></th>
@@ -10,20 +10,20 @@
     <td colspan="5">&nbsp;<br>&nbsp;</td>
 </tr>
 <tr>
-    <th rowspan="3">macOS 10.10 to 13</th>
+    <th rowspan="3">macOS 10.10 to 14</th>
     <th rowspan="3">x86_64,<br>arm64</th>
     <th><abbr title="Graphical User Interface">GUI</abbr></th>
-    <td><a href="//mediaarea.net/download/binary/mediainfo-gui/24.01/MediaInfo_GUI_24.01_Mac.dmg">v24.01</a></td>
+    <td><a href="//mediaarea.net/download/binary/mediainfo-gui/24.01.1/MediaInfo_GUI_24.01.1_Mac.dmg">v24.01</a></td>
     <td>(free of charge GUI, but it is not well integrated in your OS: it is the old-style GUI I first used. Prefer the Mac App Store version)</td>
 </tr>
 <tr>
     <th><abbr title="Command Line Interface">CLI</abbr></th>
-    <td><a href="//mediaarea.net/download/binary/mediainfo/24.01/MediaInfo_CLI_24.01_Mac.dmg">v24.01</a><small> Graph v24.01 (installer: <a href="//mediaarea.net/download/binary/mediainfo-graph-plugin/24.01/MediaInfo_GraphPlugin_CLI_24.01_Mac.dmg">dmg</a>)</small></td>
+    <td><a href="//mediaarea.net/download/binary/mediainfo/24.01.1/MediaInfo_CLI_24.01.1_Mac.dmg">v24.01.1</a><small> Graph v24.01 (installer: <a href="//mediaarea.net/download/binary/mediainfo-graph-plugin/24.01/MediaInfo_GraphPlugin_CLI_24.01_Mac.dmg">dmg</a>)</small></td>
     <td>&nbsp;</td>
 </tr>
 <tr>
     <th><abbr title="Dynamic Library">DyLib</abbr></th>
-    <td><a href="//mediaarea.net/download/binary/libmediainfo0/24.01/MediaInfo_DLL_24.01_Mac_x86_64+arm64.tar.bz2">v24.01</a></td>
+    <td><a href="//mediaarea.net/download/binary/libmediainfo0/24.01.1/MediaInfo_DLL_24.01.1_Mac_x86_64+arm64.tar.bz2">v24.01.1</a></td>
     <td>&nbsp;</td>
 </tr>
 <tr class="old-files">


### PR DESCRIPTION
Fixes MediaArea/MediaInfoLib#1961